### PR TITLE
MultimediaModelBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -125,6 +125,7 @@ class AppKernel extends Kernel
 
             new Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle(),
             new Application\Multimedia\CoreBundle\MultimediaCoreBundle(),
+            new Application\Multimedia\ModelBundle\MultimediaModelBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {

--- a/app/DoctrineMigrations/Version20150326165916.php
+++ b/app/DoctrineMigrations/Version20150326165916.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20150326165916 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE course (id INT AUTO_INCREMENT NOT NULL, name TEXT DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE student (id INT AUTO_INCREMENT NOT NULL, id_course INT DEFAULT NULL, name TEXT DEFAULT NULL, INDEX fk_course (id_course), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE student ADD CONSTRAINT FK_B723AF3330A9DA54 FOREIGN KEY (id_course) REFERENCES course (id)');
+        $this->addSql('ALTER TABLE order__order CHANGE currency currency CHAR(3) DEFAULT NULL');
+        $this->addSql('ALTER TABLE order__order_audit CHANGE currency currency CHAR(3) DEFAULT NULL');
+        $this->addSql('ALTER TABLE invoice__invoice CHANGE currency currency CHAR(3) NOT NULL');
+        $this->addSql('ALTER TABLE invoice__invoice_audit CHANGE currency currency CHAR(3) DEFAULT NULL');
+        $this->addSql('ALTER TABLE basket__basket CHANGE currency currency CHAR(3) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE student DROP FOREIGN KEY FK_B723AF3330A9DA54');
+        $this->addSql('DROP TABLE course');
+        $this->addSql('DROP TABLE student');
+        $this->addSql('ALTER TABLE basket__basket CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE invoice__invoice CHANGE currency currency CHAR(3) NOT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE invoice__invoice_audit CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE order__order CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE order__order_audit CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/DependencyInjection/Configuration.php
+++ b/src/Application/Multimedia/ModelBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('multimedia_model');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/DependencyInjection/MultimediaModelExtension.php
+++ b/src/Application/Multimedia/ModelBundle/DependencyInjection/MultimediaModelExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class MultimediaModelExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/Entity/Course.php
+++ b/src/Application/Multimedia/ModelBundle/Entity/Course.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Course
+ */
+class Course
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var integer
+     */
+    private $id;
+
+
+    /**
+     * Set name
+     *
+     * @param string $name
+     * @return Course
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get name
+     *
+     * @return string 
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get id
+     *
+     * @return integer 
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/Entity/Student.php
+++ b/src/Application/Multimedia/ModelBundle/Entity/Student.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Student
+ */
+class Student
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var integer
+     */
+    private $id;
+
+    /**
+     * @var \Application\Multimedia\ModelBundle\Entity\Course
+     */
+    private $idCourse;
+
+
+    /**
+     * Set name
+     *
+     * @param string $name
+     * @return Student
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get name
+     *
+     * @return string 
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get id
+     *
+     * @return integer 
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set idCourse
+     *
+     * @param \Application\Multimedia\ModelBundle\Entity\Course $idCourse
+     * @return Student
+     */
+    public function setIdCourse(\Application\Multimedia\ModelBundle\Entity\Course $idCourse = null)
+    {
+        $this->idCourse = $idCourse;
+
+        return $this;
+    }
+
+    /**
+     * Get idCourse
+     *
+     * @return \Application\Multimedia\ModelBundle\Entity\Course 
+     */
+    public function getIdCourse()
+    {
+        return $this->idCourse;
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/MultimediaModelBundle.php
+++ b/src/Application/Multimedia/ModelBundle/MultimediaModelBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MultimediaModelBundle extends Bundle
+{
+}

--- a/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Course.orm.xml
+++ b/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Course.orm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="Application\Multimedia\ModelBundle\Entity\Course" table="course">
+    <id name="id" type="integer" column="id">
+      <generator strategy="IDENTITY"/>
+    </id>
+    <field name="name" type="text" column="name" length="65535" nullable="true"/>
+  </entity>
+</doctrine-mapping>

--- a/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Student.orm.xml
+++ b/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Student.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="Application\Multimedia\ModelBundle\Entity\Student" table="student">
+    <indexes>
+      <index name="fk_course" columns="id_course"/>
+    </indexes>
+    <id name="id" type="integer" column="id">
+      <generator strategy="IDENTITY"/>
+    </id>
+    <field name="name" type="text" column="name" length="65535" nullable="true"/>
+    <many-to-one field="idCourse" target-entity="Course">
+      <join-columns>
+        <join-column name="id_course" referenced-column-name="id"/>
+      </join-columns>
+    </many-to-one>
+  </entity>
+</doctrine-mapping>

--- a/src/Application/Multimedia/ModelBundle/Resources/config/services.xml
+++ b/src/Application/Multimedia/ModelBundle/Resources/config/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <!--
+    <services>
+        <service id="multimedia_model.example" class="Application\Multimedia\ModelBundle\Example">
+            <argument type="service" id="service_id" />
+            <argument>plain_value</argument>
+            <argument>%parameter_name%</argument>
+        </service>
+    </services>
+    -->
+</container>

--- a/src/Application/Multimedia/ModelBundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/Application/Multimedia/ModelBundle/Tests/Controller/DefaultControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DefaultControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/hello/Fabien');
+
+        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
+    }
+}


### PR DESCRIPTION
This PR aims at adding MultimediaModelBundle 

#### procedure
    php app/bundle generate:bundle

    # I don't need Controller and Views directories because i should interact just with DB, don't need Routing either
    rm -rf src/Application/Multimedia/ModelBundle/Resources/views/
    rm -rf src/Application/Multimedia/ModelBundle/Controller/

#### DB Query

    create table course (
	id integer primary key,
	name text     
    );
    create table student (
	id integer primary key,
	name text,
	id_course integer,
    constraint fk_course foreign key (id_course) references course(id)
    );

You need to change `./app/config/parameters.yml` to point the new database.
Then you can run the following command to create the metadatafiles for each table :
 
    php app/console doctrine:mapping:import --force MultimediaModelBundle xml

Generated the entities from the metadata previously created : 
    
    php app/console doctrine:generate:entities MultimediaModelBundle

Generated the migration file to keep the history of database change